### PR TITLE
build: Bump PHP version and dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '8 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / SimpleTypes
 
-[![CI](https://github.com/JBZoo/SimpleTypes/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/SimpleTypes/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/SimpleTypes/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/SimpleTypes?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/SimpleTypes/coverage.svg)](https://shepherd.dev/github/JBZoo/SimpleTypes)    [![Psalm Level](https://shepherd.dev/github/JBZoo/SimpleTypes/level.svg)](https://shepherd.dev/github/JBZoo/SimpleTypes)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/simpletypes/badge)](https://www.codefactor.io/repository/github/jbzoo/simpletypes/issues)    
+[![CI](https://github.com/JBZoo/SimpleTypes/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/SimpleTypes/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/SimpleTypes/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/SimpleTypes?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/SimpleTypes/coverage.svg)](https://shepherd.dev/github/JBZoo/SimpleTypes)    [![Psalm Level](https://shepherd.dev/github/JBZoo/SimpleTypes/level.svg)](https://shepherd.dev/github/JBZoo/SimpleTypes)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/simpletypes/badge)](https://www.codefactor.io/repository/github/jbzoo/simpletypes/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/simpletypes/version)](https://packagist.org/packages/jbzoo/simpletypes/)    [![Total Downloads](https://poser.pugx.org/jbzoo/simpletypes/downloads)](https://packagist.org/packages/jbzoo/simpletypes/stats)    [![Dependents](https://poser.pugx.org/jbzoo/simpletypes/dependents)](https://packagist.org/packages/jbzoo/simpletypes/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/simpletypes)](https://github.com/JBZoo/SimpleTypes/blob/master/LICENSE)
 
 
@@ -242,13 +242,13 @@ class ConfigInfo extends Config
      * @var string
      */
     public $default = 'byte';
-    
+
     /**
      * To collect or not to collect logs for each object (need additional memory a little bit)
      * @var bool
      */
     public $isDebug = true;
-    
+
     /**
      * Array of converting rules and output format
      * return array

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.1",
-        "jbzoo/utils" : "^7.1"
+        "php"         : "^8.2",
+        "jbzoo/utils" : "^7.3"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.2"
     },
 
     "autoload"          : {

--- a/src/Config/Area.php
+++ b/src/Config/Area.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Config;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Area extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Degree.php
+++ b/src/Config/Degree.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Config;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Degree extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Info.php
+++ b/src/Config/Info.php
@@ -18,6 +18,9 @@ namespace JBZoo\SimpleTypes\Config;
 
 use JBZoo\SimpleTypes\Formatter;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Info extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Length.php
+++ b/src/Config/Length.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Config;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Length extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Money.php
+++ b/src/Config/Money.php
@@ -18,6 +18,9 @@ namespace JBZoo\SimpleTypes\Config;
 
 use JBZoo\SimpleTypes\Formatter;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Money extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Temp.php
+++ b/src/Config/Temp.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Config;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Temp extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Time.php
+++ b/src/Config/Time.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Config;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Time extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Volume.php
+++ b/src/Config/Volume.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Config;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Volume extends AbstractConfig
 {
     public function __construct()

--- a/src/Config/Weight.php
+++ b/src/Config/Weight.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Config;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class Weight extends AbstractConfig
 {
     public function __construct()

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -187,15 +187,11 @@ final class Formatter
         $this->rules[$rule] = \array_merge($this->default, $newFormat);
     }
 
-    public function removeRule(string $rule): bool
+    public function removeRule(string $rule): void
     {
         if (\array_key_exists($rule, $this->rules)) {
             unset($this->rules[$rule]);
-
-            return true;
         }
-
-        return false;
     }
 
     public static function htmlAttributes(array $attributes): string

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -91,18 +91,14 @@ final class Parser
         $this->rules[$newRule] = $newRule;
     }
 
-    public function removeRule(string $rule): bool
+    public function removeRule(string $rule): void
     {
         if (\array_key_exists($rule, $this->rules)) {
             unset($this->rules[$rule]);
-
-            return true;
         }
-
-        return false;
     }
 
-    public static function cleanValue(null|float|int|string $value): float
+    public static function cleanValue(float|int|string|null $value): float
     {
         $result = \trim((string)$value);
 

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -47,7 +47,7 @@ abstract class AbstractType
     protected Parser    $parser;
     protected Formatter $formatter;
 
-    public function __construct(null|array|float|int|string $value = null, ?AbstractConfig $config = null)
+    public function __construct(array|float|int|string|null $value = null, ?AbstractConfig $config = null)
     {
         $this->prepareObject($value, $config);
     }
@@ -140,6 +140,7 @@ abstract class AbstractType
     /**
      * Experimental! Methods aliases.
      * @deprecated
+     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function __call(string $name, array $arguments): mixed
     {
@@ -287,7 +288,7 @@ abstract class AbstractType
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function compare(
-        null|array|float|int|self|string $value,
+        array|float|int|self|string|null $value,
         string $mode = '==',
         int $round = Formatter::ROUND_DEFAULT,
     ): bool {
@@ -336,12 +337,18 @@ abstract class AbstractType
         return $this->modifier(0.0, 'Set empty', $getClone);
     }
 
-    public function add(null|array|float|int|self|string $value, bool $getClone = false): self
+    /**
+     * @psalm-suppress PossiblyUnusedReturnValue
+     */
+    public function add(array|float|int|self|string|null $value, bool $getClone = false): self
     {
         return $this->customAdd($value, $getClone);
     }
 
-    public function subtract(null|array|float|int|self|string $value, bool $getClone = false): self
+    /**
+     * @psalm-suppress PossiblyUnusedReturnValue
+     */
+    public function subtract(array|float|int|self|string|null $value, bool $getClone = false): self
     {
         return $this->customAdd($value, $getClone, true);
     }
@@ -435,7 +442,7 @@ abstract class AbstractType
         return $this->modifier($this->internalValue, '<-- Function finished', $getClone);
     }
 
-    public function set(null|array|float|int|self|string $value, bool $getClone = false): self
+    public function set(array|float|int|self|string|null $value, bool $getClone = false): self
     {
         $value = $this->getValidValue($value);
 
@@ -460,7 +467,7 @@ abstract class AbstractType
         return $this;
     }
 
-    public function getValidValue(null|array|float|int|self|string $value): self
+    public function getValidValue(array|float|int|self|string|null $value): self
     {
         if ($value instanceof self) {
             $thisClass = \strtolower(static::class);
@@ -605,7 +612,7 @@ abstract class AbstractType
     }
 
     protected function customAdd(
-        null|array|float|int|self|string $value,
+        array|float|int|self|string|null $value,
         bool $getClone = false,
         bool $isSubtract = false,
     ): self {
@@ -652,7 +659,7 @@ abstract class AbstractType
         return $this;
     }
 
-    private function prepareObject(null|array|float|int|string $value = null, ?AbstractConfig $config = null): void
+    private function prepareObject(array|float|int|string|null $value = null, ?AbstractConfig $config = null): void
     {
         // $this->type = Str::class \strtolower(\str_replace(__NAMESPACE__ . '\\', '', static::class));
         $this->type = Str::getClassName(static::class, true) ?? 'UndefinedType';

--- a/src/Type/Area.php
+++ b/src/Type/Area.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Area extends AbstractType
 {
 }

--- a/src/Type/Degree.php
+++ b/src/Type/Degree.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Degree extends AbstractType
 {
     public function removeCircles(): self

--- a/src/Type/Info.php
+++ b/src/Type/Info.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Info extends AbstractType
 {
 }

--- a/src/Type/Length.php
+++ b/src/Type/Length.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Length extends AbstractType
 {
 }

--- a/src/Type/Money.php
+++ b/src/Type/Money.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Money extends AbstractType
 {
 }

--- a/src/Type/Temp.php
+++ b/src/Type/Temp.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Temp extends AbstractType
 {
 }

--- a/src/Type/Time.php
+++ b/src/Type/Time.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Time extends AbstractType
 {
 }

--- a/src/Type/Volume.php
+++ b/src/Type/Volume.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Volume extends AbstractType
 {
 }

--- a/src/Type/Weight.php
+++ b/src/Type/Weight.php
@@ -16,6 +16,10 @@ declare(strict_types=1);
 
 namespace JBZoo\SimpleTypes\Type;
 
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 final class Weight extends AbstractType
 {
 }

--- a/tests/InstancesTest.php
+++ b/tests/InstancesTest.php
@@ -38,7 +38,7 @@ final class InstancesTest extends PHPUnit
                 continue;
             }
 
-            $className = '\\JBZoo\\SimpleTypes\\Type\\' . \str_replace('.php', '', $file);
+            $className = '\JBZoo\SimpleTypes\Type\\' . \str_replace('.php', '', $file);
 
             $obj = new $className('', $config);
 
@@ -68,7 +68,7 @@ final class InstancesTest extends PHPUnit
                 continue;
             }
 
-            $className = '\\JBZoo\\SimpleTypes\\Config\\' . \str_replace('.php', '', $file);
+            $className = '\JBZoo\SimpleTypes\Config\\' . \str_replace('.php', '', $file);
 
             $obj = new $className();
             isClass(AbstractConfig::class, $obj);

--- a/tests/Types/AbstractTypeTest.php
+++ b/tests/Types/AbstractTypeTest.php
@@ -26,8 +26,8 @@ abstract class AbstractTypeTest extends PHPUnit
 
     public function val(mixed $arg = null): AbstractType
     {
-        $configName = '\\JBZoo\\SimpleTypes\\Config\\' . \ucfirst($this->type);
-        $className  = '\\JBZoo\\SimpleTypes\\Type\\' . $this->type;
+        $configName = '\JBZoo\SimpleTypes\Config\\' . \ucfirst($this->type);
+        $className  = '\JBZoo\SimpleTypes\Type\\' . $this->type;
 
         AbstractConfig::registerDefault($this->type, new $configName());
 


### PR DESCRIPTION
- Increase minimum PHP requirement to 8.2.
- Update `jbzoo/utils` to `^7.3` and `jbzoo/toolbox-dev` to `^7.2`.
- Adjust GitHub Actions CI workflow:
    - Add PHP 8.4 to the test matrix.
    - Upgrade `actions/upload-artifact` to v4.
    - Remove the scheduled cron job.
    - Add `contents: read` permission for actions.
- Add Psalm suppressions for `UnusedClass` and `PropertyNotSetInConstructor`.
- Change `Formatter::removeRule` and `Parser::removeRule` to return `void`.
- Standardize `null` position in union type hints across method signatures.